### PR TITLE
emms-tag-editor-tag-flac do not replace tags

### DIFF
--- a/lisp/emms-tag-editor.el
+++ b/lisp/emms-tag-editor.el
@@ -143,19 +143,25 @@ See also `emms-tag-editor-tag-file' and `emms-tag-editor-tag-ogg'.")
   "Commit changes to an FLAC file according to TRACK."
   (require 'emms-info-metaflac)
   (with-temp-buffer
-    (let (need val)
+    (let ((tags '("artist" "composer" "performer" "title" "album" "tracknumber" "discnumber" "date" "genre" "note"))
+	  need val)
       (mapc (lambda (tag)
               (let ((info-tag (intern (concat "info-" tag))))
                 (when (> (length (setq val (emms-track-get track info-tag))) 0)
                   (insert (upcase tag) "=" val "\n"))))
-            '("artist" "composer" "performer" "title" "album" "tracknumber" "discnumber" "date" "genre" "note"))
+            tags)
       (when (buffer-string)
-        (funcall #'call-process-region (point-min) (point-max)
-                 emms-info-metaflac-program-name nil
-                 (get-buffer-create emms-tag-editor-log-buffer)
-                 nil
-                 "--import-tags-from=-"
-                 (emms-track-name track))))))
+	(apply #'call-process-region (point-min) (point-max)
+		 emms-info-metaflac-program-name nil
+		 (get-buffer-create emms-tag-editor-log-buffer)
+		 nil
+		 (append
+		  (mapcar (lambda (tag)
+			    (concat "--remove-tag=" tag))
+			  tags)
+		  '("--import-tags-from=-")
+		  '("--")
+		  (list (emms-track-name track))))))))
 
 (defun emms-tag-editor-tag-ogg (track)
   "Commit changes to an OGG file according to TRACK."


### PR DESCRIPTION
After several tag editing of the same FLAC file, metaflac --list show
duplicates with old values.

This comes from the metaflac option '--import-tags-from=-' which append
new tags after old ones, the metaflac(1) man page specify that the use
of '--remove-all-tags' may be necessary.

I use '--remove-tag' for all tag editor supported tags instead of using
'--remove-all-tags' which would result in the deletion of user tags.
- lisp/emms-tag-editor.el (emms-tag-editor-tag-flac): Switch to 'apply'
  to pass a calculated list of arguments to 'call-process-region'.
  Pass all the '--remove-tag' option before '--import-tags-from=-'.
  Avoid errors if file name start with '-'.
